### PR TITLE
Discovery Client Services vs Instances

### DIFF
--- a/gateway/src/main/java/com/example/gatewayreactiveloadbalancer/GatewayReactiveLoadBalancerApplication.java
+++ b/gateway/src/main/java/com/example/gatewayreactiveloadbalancer/GatewayReactiveLoadBalancerApplication.java
@@ -2,12 +2,22 @@ package com.example.gatewayreactiveloadbalancer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClient;
+import org.springframework.context.ConfigurableApplicationContext;
 
 @SpringBootApplication
+@EnableDiscoveryClient
 public class GatewayReactiveLoadBalancerApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(GatewayReactiveLoadBalancerApplication.class, args);
+		ConfigurableApplicationContext ctx = SpringApplication.run(GatewayReactiveLoadBalancerApplication.class, args);
+		EurekaDiscoveryClient discoveryClient = (EurekaDiscoveryClient) ctx.getBean("discoveryClient");
+
+		// prints [version-one]
+		System.out.println(discoveryClient.getServices());
+		// prints []
+		System.out.println(discoveryClient.getInstances("version-one"));
 	}
 
 }


### PR DESCRIPTION
Added bean extraction in the Spring Main class to demonstrate instances aren't being found through the discovery client